### PR TITLE
Fix deepseek patches test assertion

### DIFF
--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_deepseek_patches.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_deepseek_patches.py
@@ -114,4 +114,4 @@ def test_module_patches(model_name, module_name, patch, inputs):
     # Generate test output
     test, *_ = module(*inputs)
 
-    torch.allclose(ref, test, atol=0, rtol=0)
+    assert torch.allclose(ref, test, atol=0, rtol=0)


### PR DESCRIPTION
## Summary
- fix `test_module_patches` to actually assert the patched output matches

## Testing
- `ruff format tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_deepseek_patches.py`
- `ruff check tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_deepseek_patches.py`